### PR TITLE
Add vk.com support

### DIFF
--- a/src/extension/content/injected.ts
+++ b/src/extension/content/injected.ts
@@ -308,7 +308,6 @@ const VK = {
       volume: Math.floor((player?.getVolume() ?? 1) ** (1 / 3) * 100),
       repeatMode: player?.isRepeatAll() ? RepeatMode.ALL : player?.isRepeatCurrentAudio() ? RepeatMode.ONE : RepeatMode.NONE,
       shuffleActive: player?.getPlaylistQueue()?.shuffled ?? false,
-
       isPlayerReady: player !== null,
     };
   },

--- a/src/extension/content/injected.ts
+++ b/src/extension/content/injected.ts
@@ -300,8 +300,8 @@ const VK = {
     let player = VK.getPlayer();
     return {
       state: !player?.getCurrentPlaylist() ? StateMode.STOPPED : player.isPlaying() ? StateMode.PLAYING : StateMode.PAUSED,
-      title: player?.stats?.currentAudio?.title ?? "",
-      artist: player?.stats?.currentAudio?.performer ?? "",
+      title: VK.unescape(player?.stats?.currentAudio?.title ?? ""),
+      artist: VK.unescape(player?.stats?.currentAudio?.performer ?? ""),
       cover: player?.stats?.currentAudio?.coverUrl_p ?? "",
       duration: player?.stats?.currentAudio?.duration ?? 0,
       position: Math.floor((player?.getCurrentProgress() ?? 0) * (player?.stats?.currentAudio?.duration ?? 0)),
@@ -337,4 +337,6 @@ const VK = {
     if (player?.getPlaylistQueue()?.shuffled) return player?.getPlaylistQueue()?.shuffle();
     return player?.getPlaylistQueue()?.shuffle(Math.random());
   },
+  // https://stackoverflow.com/questions/18106164/unescape-apostrophe-39-in-javascript
+  unescape: (input: string) => new DOMParser().parseFromString(input, "text/html").querySelector("html")!.textContent!,
 };

--- a/src/extension/content/injected.ts
+++ b/src/extension/content/injected.ts
@@ -338,5 +338,5 @@ const VK = {
     return player?.getPlaylistQueue()?.shuffle(Math.random());
   },
   // https://stackoverflow.com/questions/18106164/unescape-apostrophe-39-in-javascript
-  unescape: (input: string) => new DOMParser().parseFromString(input, "text/html").querySelector("html")!.textContent!,
+  unescape: (input: string): string => new DOMParser().parseFromString(input, "text/html").querySelector("html")!.textContent!,
 };

--- a/src/extension/content/injected.ts
+++ b/src/extension/content/injected.ts
@@ -333,8 +333,8 @@ const VK = {
   },
   toggleShuffleActive() {
     let player = VK.getPlayer();
-    if (player?.getPlaylistQueue()?.shuffled) return player?.getPlaylistQueue()?.shuffle();
-    return player?.getPlaylistQueue()?.shuffle(Math.random());
+    let shuffled = player?.getPlaylistQueue()?.shuffled;
+    return player?.getPlaylistQueue()?.shuffle(!shuffled);
   },
   // https://stackoverflow.com/questions/18106164/unescape-apostrophe-39-in-javascript
   unescape: (input: string): string => new DOMParser().parseFromString(input, "text/html").querySelector("html")!.textContent!,

--- a/src/extension/content/sites/VK.ts
+++ b/src/extension/content/sites/VK.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_UPDATE_FREQUENCY } from "../../../utils/settings";
+import { RatingSystem, RepeatMode, Site, StateMode, VKInfo } from "../../types";
+import { ContentUtils } from "../utils";
+
+let currentVKInfo: VKInfo | null = null;
+
+const site: Site = {
+  match: () => window.location.hostname === "vk.com",
+  init() {
+    setInterval(async () => {
+      const vkInfo = await ContentUtils.getVKInfo();
+      if (vkInfo) currentVKInfo = vkInfo;
+    }, DEFAULT_UPDATE_FREQUENCY / 2);
+  },
+  ready: () => currentVKInfo?.isPlayerReady ?? false,
+  ratingSystem: RatingSystem.NONE,
+  info: {
+    playerName: () => "VK",
+    state: () => currentVKInfo?.state ?? StateMode.STOPPED,
+    title: () => currentVKInfo?.title ?? "",
+    artist: () => currentVKInfo?.artist ?? "",
+    album: () => "", // there is no way to get album
+    coverUrl: () => currentVKInfo?.cover ?? "",
+    durationSeconds: () => currentVKInfo?.duration ?? 0,
+    positionSeconds: () => currentVKInfo?.position ?? 0,
+    volume: () => currentVKInfo?.volume ?? 100,
+    rating: () => 0,
+    repeatMode: () => currentVKInfo?.repeatMode ?? RepeatMode.NONE,
+    shuffleActive: () => currentVKInfo?.shuffleActive ?? false,
+  },
+  canSkipPrevious: () => true,
+  canSkipNext: () => true,
+  events: {
+    setState: (state) => ContentUtils.setVKState(state),
+    skipPrevious: () => ContentUtils.skipVKPrevious(),
+    skipNext: () => ContentUtils.skipVKNext(),
+    setPositionSeconds: (time) => ContentUtils.setVKPosition(time),
+    setPositionPercentage: null,
+    setVolume: (volume) => ContentUtils.setVKVolume(volume),
+    toggleRepeatMode: () => ContentUtils.toggleVKRepeatMode(),
+    toggleShuffleActive: () => ContentUtils.toggleVKShuffleActive(),
+    setRating: null,
+  },
+};
+
+export default site;

--- a/src/extension/content/utils.ts
+++ b/src/extension/content/utils.ts
@@ -1,7 +1,7 @@
 import { randomToken } from "../../utils/misc";
 import { defaultSettings } from "../../utils/settings";
 import { ServiceWorkerUtils } from "../../utils/sw";
-import { MediaInfo, NetflixInfo, Site, SiteInfo, StateMode, YouTubeInfo } from "../types";
+import { MediaInfo, NetflixInfo, Site, SiteInfo, StateMode, VKInfo, YouTubeInfo } from "../types";
 import AppleMusic from "./sites/AppleMusic";
 import Bandcamp from "./sites/Bandcamp";
 import Deezer from "./sites/Deezer";
@@ -18,6 +18,7 @@ import Soundcloud from "./sites/Soundcloud";
 import Spotify from "./sites/Spotify";
 import Tidal from "./sites/Tidal";
 import Twitch from "./sites/Twitch";
+import VK from "./sites/VK";
 import YandexMusic from "./sites/YandexMusic";
 import YouTube from "./sites/YouTube";
 import YouTubeEmbed from "./sites/YouTubeEmbed";
@@ -60,6 +61,14 @@ export const ContentUtils = {
   setYouTubeMusicVolume: (volume: number) => ContentUtils.sendMessage({ event: "setYouTubeMusicVolume", data: volume }),
   seekNetflix: (time: number) => ContentUtils.sendMessage({ event: "seekNetflix", data: time }),
   getNetflixInfo: () => ContentUtils.sendMessage<NetflixInfo>({ event: "getNetflixInfo" }),
+  getVKInfo: () => ContentUtils.sendMessage<VKInfo>({ event: "getVKInfo" }),
+  setVKState: (state: StateMode) => ContentUtils.sendMessage({ event: "setVKState", data: state }),
+  skipVKPrevious: () => ContentUtils.sendMessage({ event: "skipVKPrevious" }),
+  skipVKNext: () => ContentUtils.sendMessage({ event: "skipVKNext" }),
+  setVKPosition: (time: number) => ContentUtils.sendMessage({ event: "setVKPosition", data: time }),
+  setVKVolume: (volume: number) => ContentUtils.sendMessage({ event: "setVKVolume", data: volume }),
+  toggleVKRepeatMode: () => ContentUtils.sendMessage({ event: "toggleVKRepeatMode" }),
+  toggleVKShuffleActive: () => ContentUtils.sendMessage({ event: "toggleVKShuffleActive" }),
 };
 
 export const getCurrentSite = (): Site | null => {
@@ -79,6 +88,7 @@ export const getCurrentSite = (): Site | null => {
     Spotify,
     Tidal,
     Twitch,
+    VK,
     YandexMusic,
     YouTube,
     YouTubeEmbed,

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -184,3 +184,17 @@ export type NetflixInfo = {
   };
   isPlayerReady: boolean;
 };
+
+export type VKInfo = {
+  state: StateMode;
+  title: string;
+  artist: string;
+  cover: string;
+  duration: number;
+  position: number;
+  volume: number;
+  repeatMode: RepeatMode;
+  shuffleActive: boolean;
+
+  isPlayerReady: boolean;
+};

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -195,6 +195,5 @@ export type VKInfo = {
   volume: number;
   repeatMode: RepeatMode;
   shuffleActive: boolean;
-
   isPlayerReady: boolean;
 };

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -20,6 +20,7 @@ export type TSupportedSites =
   | "Spotify"
   | "Tidal"
   | "Twitch"
+  | "VK"
   | "Yandex Music"
   | "YouTube"
   | "YouTube Embeds"
@@ -40,6 +41,7 @@ export const SupportedSites: TSupportedSites[] = [
   "Spotify",
   "Tidal",
   "Twitch",
+  "VK",
   "Yandex Music",
   "YouTube",
   "YouTube Embeds",


### PR DESCRIPTION
Hello! I have added support for the Russian social network [vk.com](https://vk.com/audio). It contains a lot of licensed music, as well as tracks added by users. I suppose you can test it this without a VPN, just not all the music will be available.

All requests are made to the internal API of the site, so `querySelector` is not used at all. This is my first experience writing TypeScript, so I appreciate any tips to improve the code.

Thanks.