### PR TITLE
feat: Add Zvuk.com support & fix Yandex Music for new player UI

### DIFF
--- a/src/extension/content/content.ts
+++ b/src/extension/content/content.ts
@@ -93,6 +93,11 @@ const siteIndex: SiteIndex[] = [
     exec,
   },
   {
+    match: () => window.location.hostname === "zvuk.com" || window.location.hostname === "sber-zvuk.com",
+    name: "Zvuk",
+    exec,
+  },
+  {
     match: () => window.location.hostname === "music.yandex.ru" || window.location.hostname === "music.yandex.com",
     name: "Yandex Music",
     exec,

--- a/src/extension/content/injected/injected.ts
+++ b/src/extension/content/injected/injected.ts
@@ -17,6 +17,7 @@ import Spotify from "./sites/Spotify";
 import Tidal from "./sites/Tidal";
 import Twitch from "./sites/Twitch";
 import VK from "./sites/VK";
+import Zvuk from "./sites/Zvuk";
 import YandexMusic from "./sites/YandexMusic";
 import YouTube from "./sites/YouTube";
 import YouTubeEmbeds from "./sites/YouTubeEmbeds";
@@ -45,6 +46,7 @@ const sites = [
   Tidal,
   Twitch,
   VK,
+  Zvuk,
   YandexMusic,
   YouTube,
   YouTubeEmbeds,

--- a/src/extension/content/injected/sites/YandexMusic.ts
+++ b/src/extension/content/injected/sites/YandexMusic.ts
@@ -202,13 +202,28 @@ const YandexMusic: Site = {
       button.click();
     },
   },
-  controls: () =>
-    createDefaultControls(YandexMusic, {
+  controls: () => {
+    // Check if volume/position sliders are available
+    const hasVolumeSlider = !!(
+      document.querySelector('input[aria-label="Управление громкостью"]') ??
+      document.querySelector('input[aria-label="Manage volume"]') ??
+      document.querySelector('.volume__btn')
+    );
+    const hasPositionSlider = !!(
+      document.querySelector('input[aria-label="Управление таймкодом"]') ??
+      document.querySelector('input[aria-label="Manage time code"]') ??
+      document.querySelector('.progress__progress')
+    );
+    
+    return createDefaultControls(YandexMusic, {
       ratingSystem: RatingSystem.LIKE_DISLIKE,
       availableRepeat: Repeat.NONE | Repeat.ALL | Repeat.ONE,
       canSkipPrevious: notDisabled(document.querySelector<HTMLButtonElement>(".d-icon_track-prev") ?? document.querySelector<HTMLButtonElement>("div[class*=\"SonataControlsDesktop_sonataButtons\"] button[aria-label*=\"Предыдущ\"]") ?? document.querySelector<HTMLButtonElement>("div[class*=\"SonataControlsDesktop_sonataButtons\"] button[aria-label*=\"Prev\"]")),
       canSkipNext: notDisabled(document.querySelector<HTMLButtonElement>(".d-icon_track-next") ?? document.querySelector<HTMLButtonElement>("div[class*=\"SonataControlsDesktop_sonataButtons\"] button[aria-label*=\"Следующ\"]") ?? document.querySelector<HTMLButtonElement>("div[class*=\"SonataControlsDesktop_sonataButtons\"] button[aria-label*=\"Next\"]")),
-    }),
+      canSetVolume: hasVolumeSlider,
+      canSetPosition: hasPositionSlider && YandexMusic.info.duration() > 0,
+    });
+  },
 };
 
 export default YandexMusic;

--- a/src/extension/content/injected/sites/YandexMusic.ts
+++ b/src/extension/content/injected/sites/YandexMusic.ts
@@ -136,9 +136,27 @@ const YandexMusic: Site = {
       );
     },
     setVolume: (volume) => {
+      // Новый плеер: input[type="range"] с max="1"
+      const rangeInput = document.querySelector<HTMLInputElement>('input[aria-label="Управление громкостью"]')
+        ?? document.querySelector<HTMLInputElement>('input[aria-label="Manage volume"]');
+      
+      if (rangeInput) {
+        const normalizedVolume = volume / 100; // 0-100 -> 0-1
+        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+        if (nativeInputValueSetter) {
+          nativeInputValueSetter.call(rangeInput, normalizedVolume);
+        } else {
+          rangeInput.value = String(normalizedVolume);
+        }
+        rangeInput.dispatchEvent(new Event('input', { bubbles: true }));
+        rangeInput.dispatchEvent(new Event('change', { bubbles: true }));
+        return;
+      }
+
+      // Старый плеер: только mute/unmute через кнопку
       const currVolume = YandexMusic.info.volume();
       if ((currVolume === 0 && volume > 0) || (currVolume === 100 && volume < 100)) {
-        const button = document.querySelector<HTMLButtonElement>(".volume__btn") ?? document.querySelector<HTMLButtonElement>('div[class*="ChangeVolume_root"] button');
+        const button = document.querySelector<HTMLButtonElement>(".volume__btn");
         if (!button) throw new EventError();
         button.click();
       }

--- a/src/extension/content/injected/sites/YandexMusic.ts
+++ b/src/extension/content/injected/sites/YandexMusic.ts
@@ -95,7 +95,7 @@ const YandexMusic: Site = {
     setPosition: (seconds) => {
       // Новый плеер: input[type="range"] с aria-label
       const rangeInput = document.querySelector<HTMLInputElement>('input[aria-label="Управление таймкодом"]') 
-        ?? document.querySelector<HTMLInputElement>('input[aria-label="Timecode control"]');
+        ?? document.querySelector<HTMLInputElement>('input[aria-label="Manage time code"]');
       
       if (rangeInput) {
         const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;

--- a/src/extension/content/injected/sites/Zvuk.ts
+++ b/src/extension/content/injected/sites/Zvuk.ts
@@ -405,14 +405,20 @@ const Zvuk: Site = {
       button.click();
     },
   },
-  controls: () =>
-    createDefaultControls(Zvuk, {
+  controls: () => {
+    const shuffleBtn = document.querySelector<HTMLButtonElement>(Selectors.shuffleButton);
+    const repeatBtn = document.querySelector<HTMLButtonElement>(Selectors.repeatButton);
+    
+    return createDefaultControls(Zvuk, {
       ratingSystem: RatingSystem.LIKE,
       availableRepeat: Repeat.NONE | Repeat.ALL | Repeat.ONE,
       canSkipPrevious: notDisabled(getPrevButton()),
       canSkipNext: notDisabled(getNextButton()),
       canSetPosition: Zvuk.info.duration() > 0, // Only in maxi mode when time is visible
-    }),
+      canSetShuffle: notDisabled(shuffleBtn),
+      canSetRepeat: notDisabled(repeatBtn),
+    });
+  },
 };
 
 export default Zvuk;

--- a/src/extension/content/injected/sites/Zvuk.ts
+++ b/src/extension/content/injected/sites/Zvuk.ts
@@ -1,0 +1,418 @@
+import { getMediaSessionCover } from "../../../../utils/misc";
+import { EventError, RatingSystem, Repeat, Site, StateMode } from "../../../types";
+import {
+  createDefaultControls,
+  createSiteInfo,
+  notDisabled,
+  setStatePlayPauseButton,
+} from "../utils";
+
+/**
+ * Selectors for Zvuk.com player.
+ * Supports both mini-player and expanded (maxi) player modes.
+ * Classes are CSS modules: ComponentName_className__hash - we match only stable prefix.
+ */
+const Selectors = {
+  // Player container
+  playerWrapper: '[class*="miniPlayerWrapper"]',
+  playerContainer: '[class*="playerContainer"]',
+  // Maxi player indicator
+  maxiPlayerActive: '[class*="miniPlayerWrapperActive"]',
+
+  // Track info (mini player)
+  coverImage: '[class*="coverButton"] img',
+  trackTitle: '[class*="infoTitle"] p',
+  artistName: '[class*="artistsWrapper"] a p',
+
+  // Track info (maxi player) - larger cover in styles_left__
+  maxiCoverImage: '[class*="styles_imageWrapper"] img',
+  maxiTrackTitle: '[class*="styles_titleLink"] p',
+  maxiArtistName: '[class*="styles_artistsWrapper__"] a p',
+
+  // Controls container - works in both modes
+  // Mini player: styles_controls__ inside styles_actions__
+  // Maxi player: styles_controls__ inside styles_controlsWrapper__
+  controlsContainer: '[class*="styles_controls__"]',
+
+  // Add/Like button
+  addButton: '[class*="btnAdd"]',
+
+  // Progress bar (mini player)
+  progressBar: '[class*="styles_bar__"]',
+  progressInner: '[class*="styles_inner__"]',
+
+  // Time display (maxi player only) - shows "1:23" and "-2:40"
+  timeContainer: '[class*="styles_time__"]',
+
+  // Volume slider - aria attribute is stable
+  volumeSlider: '[role="slider"][aria-valuetext^="Громкость"]',
+
+  // Shuffle and Repeat
+  shuffleButton: 'button:has([class*="shuffleIcon"])',
+  repeatButton: 'button:has([class*="repeatIcon"])',
+};
+
+/**
+ * Parse time string "M:SS" to seconds.
+ */
+function parseTimeToSeconds(timeStr: string): number {
+  const cleaned = timeStr.replace("-", "").trim();
+  const parts = cleaned.split(":");
+  if (parts.length === 2) {
+    const minutes = parseInt(parts[0], 10) || 0;
+    const seconds = parseInt(parts[1], 10) || 0;
+    return minutes * 60 + seconds;
+  }
+  return 0;
+}
+
+/**
+ * Get current position and duration from maxi player time display.
+ * Format: "1:23" (current) and "-2:40" (remaining)
+ */
+function getTimeInfo(): { position: number; duration: number } {
+  const container = document.querySelector(Selectors.timeContainer);
+  if (!container) return { position: 0, duration: 0 };
+
+  const spans = container.querySelectorAll("span");
+  if (spans.length < 2) return { position: 0, duration: 0 };
+
+  const currentText = spans[0]?.textContent || "";
+  const remainingText = spans[1]?.textContent || "";
+
+  const position = parseTimeToSeconds(currentText);
+  const remaining = parseTimeToSeconds(remainingText);
+  const duration = position + remaining;
+
+  return { position, duration };
+}
+
+/**
+ * Get volume from slider aria-valuenow attribute.
+ * Returns volume as number (0-100).
+ */
+function getVolume(): number {
+  const slider = document.querySelector<HTMLElement>(Selectors.volumeSlider);
+  if (!slider) return 100;
+  const value = slider.getAttribute("aria-valuenow");
+  return value ? parseFloat(value) : 100;
+}
+
+/**
+ * Find play/pause button in controls container.
+ * Second button in the controls div.
+ */
+function getPlayPauseButton(): HTMLButtonElement | null {
+  const containers = Array.from(document.querySelectorAll(Selectors.controlsContainer));
+  for (const container of containers) {
+    const buttons = container.querySelectorAll("button");
+    if (buttons.length >= 2) {
+      return buttons[1] as HTMLButtonElement;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find prev button - first button in controls.
+ */
+function getPrevButton(): HTMLButtonElement | null {
+  const containers = Array.from(document.querySelectorAll(Selectors.controlsContainer));
+  for (const container of containers) {
+    const buttons = container.querySelectorAll("button");
+    if (buttons.length >= 1) {
+      return buttons[0] as HTMLButtonElement;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find next button - last button in controls.
+ */
+function getNextButton(): HTMLButtonElement | null {
+  const containers = Array.from(document.querySelectorAll(Selectors.controlsContainer));
+  for (const container of containers) {
+    const buttons = container.querySelectorAll("button");
+    if (buttons.length >= 3) {
+      return buttons[2] as HTMLButtonElement;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if play/pause button shows pause icon (i.e., currently playing).
+ * Pause icon contains two vertical rectangles.
+ */
+function isPlaying(): boolean {
+  const button = getPlayPauseButton();
+  if (!button) return false;
+
+  const svg = button.querySelector("svg");
+  if (!svg) return false;
+
+  const paths = Array.from(svg.querySelectorAll("path"));
+  for (const path of paths) {
+    const d = path.getAttribute("d") || "";
+    // Pause icon patterns (two vertical bars)
+    // Mini: M8.25 3.09v13.82 ... m7.358
+    // Maxi: M11.549 4.326v19.348 ... m10.301
+    if (d.includes("M8.25 3.09") || d.includes("M11.549 4.326")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if shuffle is active.
+ */
+function isShuffleActive(): boolean {
+  const button = document.querySelector<HTMLButtonElement>(Selectors.shuffleButton);
+  if (!button) return false;
+  // Active state indicated by aria-pressed or specific class
+  return button.getAttribute("aria-pressed") === "true" || button.querySelector('[class*="activeIcon"]') !== null;
+}
+
+/**
+ * Check repeat state.
+ */
+function getRepeatState(): Repeat {
+  const button = document.querySelector<HTMLButtonElement>(Selectors.repeatButton);
+  if (!button) return Repeat.NONE;
+  
+  const activeIcon = button.querySelector('[class*="activeIcon"]');
+  if (!activeIcon) return Repeat.NONE;
+  
+  // Check if it's "repeat one" mode (usually has a "1" indicator or different icon)
+  const hasOneIndicator = button.textContent?.includes("1") || 
+    button.querySelector('[class*="repeatOne"]') !== null;
+  
+  if (hasOneIndicator) return Repeat.ONE;
+  return Repeat.ALL;
+}
+
+const Zvuk: Site = {
+  debug: {},
+  init: null,
+  ready: () => {
+    // Check if player is visible, has track info, AND controls are available
+    const player = document.querySelector(Selectors.playerWrapper);
+    const trackTitle = document.querySelector(Selectors.trackTitle);
+    const controls = document.querySelector(Selectors.controlsContainer);
+    return !!player && !!trackTitle && !!controls;
+  },
+  info: createSiteInfo({
+    name: () => "Zvuk",
+    title: () => {
+      // Try mediaSession first
+      if (navigator.mediaSession.metadata?.title) {
+        return navigator.mediaSession.metadata.title;
+      }
+      // Fallback to DOM
+      const titleEl = document.querySelector<HTMLElement>(Selectors.trackTitle);
+      return titleEl?.textContent?.trim() ?? "";
+    },
+    artist: () => {
+      // Try mediaSession first
+      if (navigator.mediaSession.metadata?.artist) {
+        return navigator.mediaSession.metadata.artist;
+      }
+      // Fallback to DOM - collect all artists
+      const artistEls = document.querySelectorAll<HTMLElement>(Selectors.artistName);
+      const artists: string[] = [];
+      artistEls.forEach((el) => {
+        const text = el.textContent?.trim();
+        if (text) artists.push(text);
+      });
+      return artists.join(", ");
+    },
+    album: () => {
+      // mediaSession might have album info
+      return navigator.mediaSession.metadata?.album ?? "";
+    },
+    cover: () => {
+      // Try mediaSession first
+      const mediaSessionCover = getMediaSessionCover();
+      if (mediaSessionCover) return mediaSessionCover;
+      
+      // Fallback to DOM
+      const img = document.querySelector<HTMLImageElement>(Selectors.coverImage);
+      if (!img) return "";
+      
+      // Get the largest image from srcset or src
+      const srcset = img.getAttribute("srcset");
+      if (srcset) {
+        // Parse srcset and get largest version (xlarge or large)
+        const sources = srcset.split(",").map(s => s.trim());
+        for (const source of sources.reverse()) {
+          if (source.includes("xlarge") || source.includes("large")) {
+            const url = source.split(" ")[0];
+            return url.replace(/&amp;/g, "&");
+          }
+        }
+      }
+      return img.src?.replace(/&amp;/g, "&") ?? "";
+    },
+    state: () => {
+      const player = document.querySelector(Selectors.playerWrapper);
+      if (!player) return StateMode.STOPPED;
+      return isPlaying() ? StateMode.PLAYING : StateMode.PAUSED;
+    },
+    position: () => {
+      // Maxi player shows time in "M:SS" / "-M:SS" format
+      const { position } = getTimeInfo();
+      return position;
+    },
+    duration: () => {
+      // Maxi player shows remaining time, calculate total
+      const { duration } = getTimeInfo();
+      return duration;
+    },
+    volume: () => getVolume(),
+    rating: () => {
+      // Check if track is added/liked
+      const addBtn = document.querySelector<HTMLButtonElement>(Selectors.addButton);
+      if (!addBtn) return 0;
+      // If the button shows a "check" or filled icon, track is liked
+      const svg = addBtn.querySelector("svg");
+      if (svg) {
+        const paths = Array.from(svg.querySelectorAll("path"));
+        for (const path of paths) {
+          const d = path.getAttribute("d") || "";
+          // Check for "check" or "minus" pattern indicating it's already added
+          if (d.includes("check") || d.includes("M10 2.292c2.059")) {
+            // This is the circled plus icon, not liked
+            return 0;
+          }
+        }
+      }
+      return 0;
+    },
+    repeat: () => getRepeatState(),
+    shuffle: () => isShuffleActive(),
+  }),
+  events: {
+    setState: (state) => {
+      const button = getPlayPauseButton();
+      if (!button) throw new EventError();
+
+      const currentState = Zvuk.info.state();
+      setStatePlayPauseButton(button, currentState, state);
+    },
+    skipPrevious: () => {
+      const button = getPrevButton();
+      if (!button) throw new EventError();
+      button.click();
+    },
+    skipNext: () => {
+      const button = getNextButton();
+      if (!button) throw new EventError();
+      button.click();
+    },
+    setPosition: (seconds) => {
+      // Zvuk uses a div-based progress bar, simulate drag like volume slider
+      const progressBar = document.querySelector<HTMLElement>(Selectors.progressBar);
+      if (!progressBar) throw new EventError();
+
+      const duration = Zvuk.info.duration();
+      if (duration === 0) return; // Can't seek without knowing duration
+
+      const percent = Math.max(0, Math.min(1, seconds / duration));
+      const rect = progressBar.getBoundingClientRect();
+      const clickX = rect.left + rect.width * percent;
+      const clickY = rect.top + rect.height / 2;
+
+      // Use same pattern as volume slider: mousedown + mouseup
+      progressBar.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: clickX,
+          clientY: clickY,
+        })
+      );
+      progressBar.dispatchEvent(
+        new MouseEvent("mouseup", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: clickX,
+          clientY: clickY,
+        })
+      );
+    },
+    setVolume: (volume) => {
+      const slider = document.querySelector<HTMLElement>(Selectors.volumeSlider);
+      if (!slider) throw new EventError();
+      
+      // Simulate drag on volume slider
+      const rect = slider.getBoundingClientRect();
+      const percent = volume / 100;
+      const clickX = rect.left + rect.width * percent;
+      const clickY = rect.top + rect.height / 2;
+      
+      slider.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: clickX,
+          clientY: clickY,
+        })
+      );
+      slider.dispatchEvent(
+        new MouseEvent("mouseup", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: clickX,
+          clientY: clickY,
+        })
+      );
+    },
+    setRating: () => {
+      // Toggle like/add button
+      const button = document.querySelector<HTMLButtonElement>(Selectors.addButton);
+      if (!button) throw new EventError();
+      button.click();
+    },
+    setRepeat: (repeat) => {
+      const currentRepeat = Zvuk.info.repeat();
+      if (currentRepeat === repeat) return;
+      
+      const button = document.querySelector<HTMLButtonElement>(Selectors.repeatButton);
+      if (!button) throw new EventError();
+      
+      // Cycle through repeat states until we reach desired one
+      // NONE -> ALL -> ONE -> NONE
+      const states = [Repeat.NONE, Repeat.ALL, Repeat.ONE];
+      let currentIndex = states.indexOf(currentRepeat);
+      const targetIndex = states.indexOf(repeat);
+      
+      while (currentIndex !== targetIndex) {
+        button.click();
+        currentIndex = (currentIndex + 1) % 3;
+      }
+    },
+    setShuffle: (shuffle) => {
+      if (Zvuk.info.shuffle() === shuffle) return;
+      
+      const button = document.querySelector<HTMLButtonElement>(Selectors.shuffleButton);
+      if (!button) throw new EventError();
+      button.click();
+    },
+  },
+  controls: () =>
+    createDefaultControls(Zvuk, {
+      ratingSystem: RatingSystem.LIKE,
+      availableRepeat: Repeat.NONE | Repeat.ALL | Repeat.ONE,
+      canSkipPrevious: notDisabled(getPrevButton()),
+      canSkipNext: notDisabled(getNextButton()),
+      canSetPosition: Zvuk.info.duration() > 0, // Only in maxi mode when time is visible
+    }),
+};
+
+export default Zvuk;

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -22,6 +22,7 @@ export type TSupportedSites =
   | "Tidal"
   | "Twitch"
   | "VK"
+  | "Zvuk"
   | "Yandex Music"
   | "YouTube"
   | "YouTube Embeds"
@@ -44,6 +45,7 @@ export const SupportedSites: TSupportedSites[] = [
   "Tidal",
   "Twitch",
   "VK",
+  "Zvuk",
   "Yandex Music",
   "YouTube",
   "YouTube Embeds",


### PR DESCRIPTION
## Summary

This PR adds support for Zvuk.com (Sber's music streaming service)  
and fixes Yandex Music integration after their recent player UI redesign.

## Changes

### 🎵 New: Zvuk.com Support
- Full player integration for `zvuk.com` 
- Features supported:
  - Play/Pause, Skip Previous/Next
  - Volume control
  - Shuffle and Repeat modes
  - Like/Add to library
  - Seek (in expanded player mode only)
- Uses CSS module partial matching (`[class*="prefix"]`) for resilient selectors
- Metadata extraction via MediaSession API with DOM fallback

### 🔧 Fix: Yandex Music
- Fixed [setPosition], [setVolume], ready()
- Added support for English locale

## Testing
- Zvuk.com tested in both mini-player and expanded (maxi) player modes
- Yandex Music tested with Russian  and English interfaces
- All controls verified working

## Files Changed
- src/extension/content/injected/sites/Zvuk.ts (new)
- src/extension/content/injected/sites/YandexMusic.ts
- src/extension/content/injected/injected.ts
- src/extension/content/content.ts
- src/utils/settings.ts